### PR TITLE
Refactor Scatan State & Scatan State Test

### DIFF
--- a/src/main/scala/scatan/model/components/DevelopmentCard.scala
+++ b/src/main/scala/scatan/model/components/DevelopmentCard.scala
@@ -12,6 +12,6 @@ enum DevelopmentType:
 final case class DevelopmentCard(developmentType: DevelopmentType)
 type DevelopmentCards = Map[ScatanPlayer, Seq[DevelopmentCard]]
 
-object DevelopmentCardsOfPlayers:
+object DevelopmentCards:
   def empty(players: Seq[ScatanPlayer]): DevelopmentCards =
     players.map(player => (player, Seq.empty[DevelopmentCard])).toMap

--- a/src/main/scala/scatan/model/components/ResourceCard.scala
+++ b/src/main/scala/scatan/model/components/ResourceCard.scala
@@ -13,6 +13,6 @@ final case class ResourceCard(resourceType: ResourceType)
 
 type ResourceCards = Map[ScatanPlayer, Seq[ResourceCard]]
 
-object ResourceCard:
+object ResourceCards:
   def empty(players: Seq[ScatanPlayer]): ResourceCards =
     players.map(player => (player, Seq.empty[ResourceCard])).toMap

--- a/src/main/scala/scatan/model/game/ScatanState.scala
+++ b/src/main/scala/scatan/model/game/ScatanState.scala
@@ -27,10 +27,10 @@ final case class ScatanState(
     players: Seq[ScatanPlayer],
     gameMap: GameMap,
     assignedBuildings: AssignedBuildings,
-    robberPlacement: Hexagon,
+    assignedAwards: Awards = Award.empty(),
     resourceCards: ResourceCards,
     developmentCards: DevelopmentCards,
-    assignedAwards: Awards = Award.empty()
+    robberPlacement: Hexagon
 )
 
 object ScatanState:
@@ -47,8 +47,8 @@ object ScatanState:
       players,
       GameMap(),
       Map.empty,
-      Hexagon(0, 0, 0),
-      ResourceCard.empty(players),
+      Award.empty(),
+      ResourceCards.empty(players),
       DevelopmentCardsOfPlayers.empty(players),
-      Award.empty()
+      Hexagon(0, 0, 0)
     )

--- a/src/main/scala/scatan/model/game/ScatanState.scala
+++ b/src/main/scala/scatan/model/game/ScatanState.scala
@@ -49,6 +49,6 @@ object ScatanState:
       Map.empty,
       Award.empty(),
       ResourceCards.empty(players),
-      DevelopmentCardsOfPlayers.empty(players),
+      DevelopmentCards.empty(players),
       Hexagon(0, 0, 0)
     )

--- a/src/test/scala/scatan/model/game/BaseScatanStateTest.scala
+++ b/src/test/scala/scatan/model/game/BaseScatanStateTest.scala
@@ -5,7 +5,7 @@ import scatan.model.game.config.ScatanPlayer
 import scatan.model.game.ops.EmptySpotsOps.emptySpots
 import scatan.model.map.Spot
 
-abstract class BasicScatanStateTest extends BaseTest:
+abstract class BaseScatanStateTest extends BaseTest:
 
   protected def players(n: Int): Seq[ScatanPlayer] =
     (1 to n).map(i => ScatanPlayer(s"Player $i"))

--- a/src/test/scala/scatan/model/game/BasicScatanStateTest.scala
+++ b/src/test/scala/scatan/model/game/BasicScatanStateTest.scala
@@ -1,0 +1,16 @@
+package scatan.model.game
+
+import scatan.BaseTest
+import scatan.model.game.config.ScatanPlayer
+import scatan.model.game.ops.EmptySpotsOps.emptySpots
+import scatan.model.map.Spot
+
+abstract class BasicScatanStateTest extends BaseTest:
+
+  protected def players(n: Int): Seq[ScatanPlayer] =
+    (1 to n).map(i => ScatanPlayer(s"Player $i"))
+
+  protected def emptySpot(state: ScatanState): Spot = state.emptySpots.head
+
+  val threePlayers = players(3)
+  val fourPlayers = players(4)

--- a/src/test/scala/scatan/model/game/BasicStateTest.scala
+++ b/src/test/scala/scatan/model/game/BasicStateTest.scala
@@ -1,9 +1,18 @@
 package scatan.model.game
 
 import scatan.BaseTest
+import scatan.model.GameMap
+import scatan.model.components.{
+  AssignmentInfo,
+  Award,
+  DevelopmentCard,
+  DevelopmentCardsOfPlayers,
+  ResourceCard,
+  ResourceCards
+}
 import scatan.model.game.config.ScatanPlayer
 import scatan.model.game.ops.EmptySpotsOps.emptySpots
-import scatan.model.map.Spot
+import scatan.model.map.{Hexagon, Spot}
 
 abstract class BasicStateTest extends BaseTest:
 
@@ -36,4 +45,34 @@ abstract class BasicStateTest extends BaseTest:
     yield assertThrows[IllegalArgumentException] {
       ScatanState(players(n))
     }
+  }
+
+  it should "have a gameMap" in {
+    val state = ScatanState(threePlayers)
+    state.gameMap should be(GameMap())
+  }
+
+  it should "have assigned buildings" in {
+    val state = ScatanState(threePlayers)
+    state.assignedBuildings should be(Map.empty[Spot, AssignmentInfo])
+  }
+
+  it should "have assigned awards" in {
+    val state = ScatanState(threePlayers)
+    state.assignedAwards should be(Award.empty())
+  }
+
+  it should "have resource cards" in {
+    val state = ScatanState(threePlayers)
+    state.resourceCards should be(ResourceCards.empty(threePlayers))
+  }
+
+  it should "have development cards" in {
+    val state = ScatanState(threePlayers)
+    state.developmentCards should be(DevelopmentCardsOfPlayers.empty(threePlayers))
+  }
+
+  it should "have the robber placement" in {
+    val state = ScatanState(threePlayers)
+    state.robberPlacement should be(Hexagon(0, 0, 0))
   }

--- a/src/test/scala/scatan/model/game/ScatanStateTest.scala
+++ b/src/test/scala/scatan/model/game/ScatanStateTest.scala
@@ -1,16 +1,7 @@
 package scatan.model.game
 
 import scatan.model.GameMap
-import scatan.model.components.{
-  AssignmentInfo,
-  Award,
-  DevelopmentCard,
-  DevelopmentCards,
-  ResourceCard,
-  ResourceCards
-}
-import scatan.model.game.config.ScatanPlayer
-import scatan.model.game.ops.EmptySpotsOps.emptySpots
+import scatan.model.components.{AssignmentInfo, Award, DevelopmentCards, ResourceCards}
 import scatan.model.map.{Hexagon, Spot}
 
 class ScatanStateTest extends BasicScatanStateTest:

--- a/src/test/scala/scatan/model/game/ScatanStateTest.scala
+++ b/src/test/scala/scatan/model/game/ScatanStateTest.scala
@@ -1,12 +1,11 @@
 package scatan.model.game
 
-import scatan.BaseTest
 import scatan.model.GameMap
 import scatan.model.components.{
   AssignmentInfo,
   Award,
   DevelopmentCard,
-  DevelopmentCardsOfPlayers,
+  DevelopmentCards,
   ResourceCard,
   ResourceCards
 }
@@ -14,15 +13,7 @@ import scatan.model.game.config.ScatanPlayer
 import scatan.model.game.ops.EmptySpotsOps.emptySpots
 import scatan.model.map.{Hexagon, Spot}
 
-abstract class BasicStateTest extends BaseTest:
-
-  private def players(n: Int): Seq[ScatanPlayer] =
-    (1 to n).map(i => ScatanPlayer(s"Player $i"))
-
-  protected def emptySpot(state: ScatanState): Spot = state.emptySpots.head
-
-  val threePlayers = players(3)
-  val fourPlayers = players(4)
+class ScatanStateTest extends BasicScatanStateTest:
 
   "A Scatan State" should "exists" in {
     val state = ScatanState(threePlayers)
@@ -69,7 +60,7 @@ abstract class BasicStateTest extends BaseTest:
 
   it should "have development cards" in {
     val state = ScatanState(threePlayers)
-    state.developmentCards should be(DevelopmentCardsOfPlayers.empty(threePlayers))
+    state.developmentCards should be(DevelopmentCards.empty(threePlayers))
   }
 
   it should "have the robber placement" in {

--- a/src/test/scala/scatan/model/game/ScatanStateTest.scala
+++ b/src/test/scala/scatan/model/game/ScatanStateTest.scala
@@ -4,7 +4,7 @@ import scatan.model.GameMap
 import scatan.model.components.{AssignmentInfo, Award, DevelopmentCards, ResourceCards}
 import scatan.model.map.{Hexagon, Spot}
 
-class ScatanStateTest extends BasicScatanStateTest:
+class ScatanStateTest extends BaseScatanStateTest:
 
   "A Scatan State" should "exists" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/AwardOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/AwardOpsTest.scala
@@ -5,10 +5,10 @@ import scatan.model.game.ops.BuildingOps.assignBuilding
 import scatan.model.game.ops.CardOps.assignDevelopmentCard
 import scatan.model.game.ops.EmptySpotsOps.{emptyRoadSpot, emptyStructureSpot}
 import scatan.model.game.ops.AwardOps.*
-import scatan.model.game.BasicStateTest
+import scatan.model.game.BasicScatanStateTest
 import scatan.model.game.ScatanState
 
-class AwardOpsTest extends BasicStateTest:
+class AwardOpsTest extends BasicScatanStateTest:
 
   "A State with Awards Ops" should "have awards initially not assigned" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/AwardOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/AwardOpsTest.scala
@@ -5,10 +5,10 @@ import scatan.model.game.ops.BuildingOps.assignBuilding
 import scatan.model.game.ops.CardOps.assignDevelopmentCard
 import scatan.model.game.ops.EmptySpotsOps.{emptyRoadSpot, emptyStructureSpot}
 import scatan.model.game.ops.AwardOps.*
-import scatan.model.game.BasicScatanStateTest
+import scatan.model.game.BaseScatanStateTest
 import scatan.model.game.ScatanState
 
-class AwardOpsTest extends BasicScatanStateTest:
+class AwardOpsTest extends BaseScatanStateTest:
 
   "A State with Awards Ops" should "have awards initially not assigned" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/BuildingOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/BuildingOpsTest.scala
@@ -4,12 +4,12 @@ import scatan.model.components.*
 import scatan.model.game.ops.BuildingOps.{assignBuilding, build}
 import scatan.model.game.ops.CardOps.assignResourceCard
 import scatan.model.game.ops.EmptySpotsOps.{emptyStructureSpot, emptyRoadSpot}
-import scatan.model.game.BasicStateTest
+import scatan.model.game.BasicScatanStateTest
 import scatan.model.game.ScatanState
 import scatan.model.map.StructureSpot
 import scatan.model.map.RoadSpot
 
-class BuildingOpsTest extends BasicStateTest:
+class BuildingOpsTest extends BasicScatanStateTest:
 
   private def spotToBuildStructure(state: ScatanState): StructureSpot =
     state.emptyStructureSpot.head

--- a/src/test/scala/scatan/model/game/ops/BuildingOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/BuildingOpsTest.scala
@@ -4,12 +4,12 @@ import scatan.model.components.*
 import scatan.model.game.ops.BuildingOps.{assignBuilding, build}
 import scatan.model.game.ops.CardOps.assignResourceCard
 import scatan.model.game.ops.EmptySpotsOps.{emptyStructureSpot, emptyRoadSpot}
-import scatan.model.game.BasicScatanStateTest
+import scatan.model.game.BaseScatanStateTest
 import scatan.model.game.ScatanState
 import scatan.model.map.StructureSpot
 import scatan.model.map.RoadSpot
 
-class BuildingOpsTest extends BasicScatanStateTest:
+class BuildingOpsTest extends BaseScatanStateTest:
 
   private def spotToBuildStructure(state: ScatanState): StructureSpot =
     state.emptyStructureSpot.head

--- a/src/test/scala/scatan/model/game/ops/DevCardOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/DevCardOpsTest.scala
@@ -4,9 +4,9 @@ import scatan.lib.game.Game
 import scatan.model.components.{DevelopmentCard, DevelopmentType}
 import scatan.model.game.ScatanState
 import scatan.model.game.ops.CardOps.{assignDevelopmentCard, consumeDevelopmentCard}
-import scatan.model.game.BasicScatanStateTest
+import scatan.model.game.BaseScatanStateTest
 
-class DevCardOpsTest extends BasicScatanStateTest:
+class DevCardOpsTest extends BaseScatanStateTest:
 
   "A State with development cards Ops" should "have empty development cards when game start" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/DevCardOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/DevCardOpsTest.scala
@@ -4,9 +4,9 @@ import scatan.lib.game.Game
 import scatan.model.components.{DevelopmentCard, DevelopmentType}
 import scatan.model.game.ScatanState
 import scatan.model.game.ops.CardOps.{assignDevelopmentCard, consumeDevelopmentCard}
-import scatan.model.game.BasicStateTest
+import scatan.model.game.BasicScatanStateTest
 
-class DevCardOpsTest extends BasicStateTest:
+class DevCardOpsTest extends BasicScatanStateTest:
 
   "A State with development cards Ops" should "have empty development cards when game start" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/ResCardOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/ResCardOpsTest.scala
@@ -7,10 +7,10 @@ import scatan.model.game.ops.EmptySpotsOps.emptyStructureSpot
 import scatan.model.map.HexagonInMap.layer
 import scatan.model.map.{RoadSpot, Spot, StructureSpot}
 import scatan.utils.UnorderedTriple
-import scatan.model.game.BasicScatanStateTest
+import scatan.model.game.BaseScatanStateTest
 import scatan.model.game.ScatanState
 
-class ResCardOpsTest extends BasicScatanStateTest:
+class ResCardOpsTest extends BaseScatanStateTest:
 
   extension (state: ScatanState)
     /** This method assigns resources to players based on the number of the hexagons where their buildings are located.

--- a/src/test/scala/scatan/model/game/ops/ResCardOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/ResCardOpsTest.scala
@@ -7,10 +7,10 @@ import scatan.model.game.ops.EmptySpotsOps.emptyStructureSpot
 import scatan.model.map.HexagonInMap.layer
 import scatan.model.map.{RoadSpot, Spot, StructureSpot}
 import scatan.utils.UnorderedTriple
-import scatan.model.game.BasicStateTest
+import scatan.model.game.BasicScatanStateTest
 import scatan.model.game.ScatanState
 
-class ResCardOpsTest extends BasicStateTest:
+class ResCardOpsTest extends BasicScatanStateTest:
 
   extension (state: ScatanState)
     /** This method assigns resources to players based on the number of the hexagons where their buildings are located.

--- a/src/test/scala/scatan/model/game/ops/ResCardOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/ResCardOpsTest.scala
@@ -1,6 +1,6 @@
 package scatan.model.game.ops
 
-import scatan.model.components.{BuildingType, ResourceCard, ResourceType}
+import scatan.model.components.{BuildingType, ResourceCard, ResourceCards, ResourceType}
 import scatan.model.game.ops.BuildingOps.assignBuilding
 import scatan.model.game.ops.CardOps.assignResourcesFromNumber
 import scatan.model.game.ops.EmptySpotsOps.emptyStructureSpot
@@ -34,7 +34,7 @@ class ResCardOpsTest extends BasicStateTest:
 
   "A State with resource cards Ops" should "have an empty resource card deck initially" in {
     val state = ScatanState(threePlayers)
-    state.resourceCards should be(ResourceCard.empty(threePlayers))
+    state.resourceCards should be(ResourceCards.empty(threePlayers))
   }
 
   it should "assign a resource card to the player who has a settlement on a spot having that resource terrain" in {

--- a/src/test/scala/scatan/model/game/ops/RobberOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/RobberOpsTest.scala
@@ -2,10 +2,10 @@ package scatan.model.game.ops
 
 import scatan.model.map.Hexagon
 import scatan.model.game.ops.RobberOps.moveRobber
-import scatan.model.game.BasicStateTest
+import scatan.model.game.BasicScatanStateTest
 import scatan.model.game.ScatanState
 
-class RobberOpsTest extends BasicStateTest:
+class RobberOpsTest extends BasicScatanStateTest:
 
   "A State with Robber Ops" should "have a robber in the center of the map initially" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/RobberOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/RobberOpsTest.scala
@@ -2,10 +2,10 @@ package scatan.model.game.ops
 
 import scatan.model.map.Hexagon
 import scatan.model.game.ops.RobberOps.moveRobber
-import scatan.model.game.BasicScatanStateTest
+import scatan.model.game.BaseScatanStateTest
 import scatan.model.game.ScatanState
 
-class RobberOpsTest extends BasicScatanStateTest:
+class RobberOpsTest extends BaseScatanStateTest:
 
   "A State with Robber Ops" should "have a robber in the center of the map initially" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/ScoreOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/ScoreOpsTest.scala
@@ -5,10 +5,10 @@ import scatan.model.game.ScatanState
 import scatan.model.game.ops.BuildingOps.assignBuilding
 import scatan.model.game.ops.EmptySpotsOps.emptyStructureSpot
 import scatan.model.game.ops.ScoreOps.*
-import scatan.model.game.BasicStateTest
+import scatan.model.game.BasicScatanStateTest
 import scatan.model.game.ops.EmptySpotsOps.emptyRoadSpot
 
-class ScoreOpsTest extends BasicStateTest:
+class ScoreOpsTest extends BasicScatanStateTest:
 
   "A State with Scores Ops" should "have an empty scoreboard initially" in {
     val state = ScatanState(threePlayers)

--- a/src/test/scala/scatan/model/game/ops/ScoreOpsTest.scala
+++ b/src/test/scala/scatan/model/game/ops/ScoreOpsTest.scala
@@ -5,10 +5,10 @@ import scatan.model.game.ScatanState
 import scatan.model.game.ops.BuildingOps.assignBuilding
 import scatan.model.game.ops.EmptySpotsOps.emptyStructureSpot
 import scatan.model.game.ops.ScoreOps.*
-import scatan.model.game.BasicScatanStateTest
+import scatan.model.game.BaseScatanStateTest
 import scatan.model.game.ops.EmptySpotsOps.emptyRoadSpot
 
-class ScoreOpsTest extends BasicScatanStateTest:
+class ScoreOpsTest extends BaseScatanStateTest:
 
   "A State with Scores Ops" should "have an empty scoreboard initially" in {
     val state = ScatanState(threePlayers)


### PR DESCRIPTION
Improved convention across naming.
Moved out test from BaseScatanStateTest that were executed by all test extending it.